### PR TITLE
Adds protobuf-dev as a dependency in the package.xml.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
 
+  <depend>protobuf-dev</depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
`drake_vendor` needs `protobuf-dev` to be buildable.
When working with the entire worskpace this does not come up because `delphyne` is installing several packages and `protobuf-dev` is one of them.