### PR TITLE
prereqs: get drake_installer path from `dirname $0`

### DIFF
--- a/prereqs
+++ b/prereqs
@@ -10,10 +10,11 @@ prereqs.assert_sudo
 
 if prereqs.tag_applies "drake|all"; then
     prereqs.apt install python3-requests
+    SCRIPT_DIR=$(dirname $0)
 	if prereqs.interactive; then
-	    PATH=".":${PATH} drake_installer --interactive
+	    ${SCRIPT_DIR}/drake_installer --interactive
 	else
-	    PATH=".":${PATH} drake_installer
+	    ${SCRIPT_DIR}/drake_installer
 	fi
 	if [ $? -ne 0 ]; then
 	    prereqs.die "drake_installer failed"


### PR DESCRIPTION
In the [current instructions for setting up a workspace](https://github.com/ToyotaResearchInstitute/dsim-repos-index#update-your-workspace), step 4 is to invoke the following command from the root of the `maliput_ws/` workspace:

* `sudo prereqs-install -t all src`

This command currently fails to find the `drake_installer` script:

~~~
• Installing prerequisites at  /home/scpeters/clone/dsim-repos-index/maliput_ws/src/drake_vendor/prereqs
/home/scpeters/clone/dsim-repos-index/maliput_ws
Reading package lists... Done
Building dependency tree       
Reading state information... Done
python3-requests is already the newest version (2.18.4-2ubuntu0.1).
0 upgraded, 0 newly installed, 0 to remove and 70 not upgraded.
/home/scpeters/clone/dsim-repos-index/maliput_ws/src/drake_vendor/prereqs: line 15: drake_installer: command not found
The drake vendor source distribution prerequisites script has experienced an error on line 16 while running the command PATH=".":${PATH} drake_installer --interactive
└─ ✗ Exited with non-zero exit code:  127
~~~

I believe adding `.` to the `PATH` in the `drake_vendor/prereqs` script doesn't work when called from another folder. In order to find the path to `drake_installer`; one can use `dirname $0`. There are [more complex solutions](https://stackoverflow.com/a/246128) as well, but this seems to fix the recommended installation command.

(I discovered this while re-instantiating my workspace from scratch)