### PR TITLE
workflow: use ignition-citadel dependencies

### DIFF
--- a/.github/dependencies.repos
+++ b/.github/dependencies.repos
@@ -6,7 +6,7 @@ repositories:
   ign-gui0:
     type: git
     url: https://github.com/scpeters/ign-gui
-    version: gui0_blueprint
+    version: gui0_citadel
   pybind11:
     type: git
     url: https://github.com/RobotLocomotion/pybind11.git

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
       run: |
         rosdep update;
         rosdep install  -i -y --rosdistro ${ROS_DISTRO} \
-          --skip-keys "ignition-transport7 ignition-msgs4 ignition-math6 ignition-common3 ignition-gui0 ignition-rendering2 pybind11" \
+          --skip-keys "ignition-transport8 ignition-msgs5 ignition-math6 ignition-common3 ignition-gui0 ignition-gui3 ignition-rendering3 pybind11" \
           --from-paths src
     - name: colcon build libraries
       shell: bash


### PR DESCRIPTION
Part of ToyotaResearchInstitute/delphyne-gui#332, pairs with https://github.com/ToyotaResearchInstitute/delphyne/pull/768, https://github.com/ToyotaResearchInstitute/delphyne-gui/pull/360, and https://github.com/ToyotaResearchInstitute/dsim-repos-index/pull/178