### PR TITLE
Uses maliput_integration_tests instead of maliput-integration-tests.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
-        repository: ToyotaResearchInstitute/maliput-integration-tests
+        repository: ToyotaResearchInstitute/maliput_integration_tests
         fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/maliput_integration_tests
         token: ${{ secrets.MALIPUT_TOKEN }}


### PR DESCRIPTION
Part of https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/180