### PR TITLE
Check if commit values match before checking date

### DIFF
--- a/cmake/drake-extras.cmake.in
+++ b/cmake/drake-extras.cmake.in
@@ -36,7 +36,8 @@ string(REPLACE " " ";" drake_VERSION_LIST ${drake_VERSION})
 list(GET drake_VERSION_LIST 0 drake_RELEASE_DATE)
 list(GET drake_VERSION_LIST 1 drake_RELEASE_COMMIT)
 
-if("${drake_RELEASE_DATE}" LESS "${drake_EXPECTED_RELEASE_DATE}")
+if((NOT "${drake_RELEASE_COMMIT}" STREQUAL "${drake_EXPECTED_RELEASE_COMMIT}")
+    AND ("${drake_RELEASE_DATE}" LESS "${drake_EXPECTED_RELEASE_DATE}"))
   message(FATAL_ERROR
     " =====================================================================\n"
     " ${drake_RELEASE_DATE} < ${drake_EXPECTED_RELEASE_DATE}\n"
@@ -46,7 +47,8 @@ if("${drake_RELEASE_DATE}" LESS "${drake_EXPECTED_RELEASE_DATE}")
   )
 endif()
 
-if("${drake_RELEASE_DATE}" GREATER "${drake_EXPECTED_RELEASE_DATE}")
+if((NOT "${drake_RELEASE_COMMIT}" STREQUAL "${drake_EXPECTED_RELEASE_COMMIT}")
+    AND ("${drake_RELEASE_DATE}" GREATER "${drake_EXPECTED_RELEASE_DATE}"))
   message(FATAL_ERROR
     " =====================================================================\n"
     " ${drake_RELEASE_DATE} > ${drake_EXPECTED_RELEASE_DATE}\n"

--- a/drake_installer
+++ b/drake_installer
@@ -157,9 +157,16 @@ def check_installed_version(install_dir: str, verification_file) -> InstalledVer
     if filecmp.cmp(verification_file, installed_verification_file, shallow=False):
         return InstalledVersionCompatibility.COMPATIBLE
     with open(verification_file) as f:
-        verification_datetime = f.read().split()[0]
+        version_fields = f.read().split()
+        verification_datetime = version_fields[0]
+        verification_commit = version_fields[1]
     with open(installed_verification_file) as f:
-        installed_datetime = f.read().split()[0]
+        version_fields = f.read().split()
+        installed_datetime = version_fields[0]
+        installed_commit = version_fields[1]
+    if verification_commit == installed_commit:
+        # compatible if commit sha matches even if date doesn't
+        return InstalledVersionCompatibility.COMPATIBLE
     if verification_datetime > installed_datetime:
         return InstalledVersionCompatibility.OLDER
     else:


### PR DESCRIPTION
The timestamps in the VERSION.TXT files are different in the
bionic and focal tarballs, even thought the commit strings
are the same. This updates the logic to only complain about
data mismatches if the commit values are different.

Part of https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/196