### PR TITLE
Removes malidrive from CI checks.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,12 +74,6 @@ jobs:
         path: ${{ env.ROS_WS }}/src/maliput_malidrive
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
-      with:
-        repository: ToyotaResearchInstitute/malidrive
-        fetch-depth: 0
-        path: ${{ env.ROS_WS }}/src/malidrive
-        token: ${{ secrets.MALIPUT_TOKEN }}
-    - uses: actions/checkout@v2
       if: matrix.ubuntu == '20.04'
       with:
         repository: ToyotaResearchInstitute/delphyne


### PR DESCRIPTION
Part of https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/224

Removes `malidrive` from CI build and test check.